### PR TITLE
Fix invalid colorbar property

### DIFF
--- a/verdant-intelligence/verdant_core.py
+++ b/verdant-intelligence/verdant_core.py
@@ -257,11 +257,22 @@ class VerdantMind:
             color.append(t.temperature)
             size.append(10 + t.stability * 20)
         node_trace = go.Scatter(
-            x=node_x, y=node_y, mode='markers', text=text, hoverinfo='text',
-            marker=dict(size=size, color=color, colorscale='Plasma',
-                        colorbar=dict(thickness=15, title='Cognitive Temperature',
-                                      xanchor='left', titleside='right'),
-                        line=dict(width=2, color='white'))
+            x=node_x,
+            y=node_y,
+            mode="markers",
+            text=text,
+            hoverinfo="text",
+            marker=dict(
+                size=size,
+                color=color,
+                colorscale="Plasma",
+                colorbar=dict(
+                    thickness=15,
+                    title=dict(text="Cognitive Temperature", side="right"),
+                    xanchor="left",
+                ),
+                line=dict(width=2, color="white"),
+            ),
         )
         fig = go.Figure(data=[edge_trace, node_trace], layout=go.Layout(
             title='Verdant Intelligence: Thermodynamic Thought Network',


### PR DESCRIPTION
## Summary
- fix invalid plotly `titleside` colorbar option

## Testing
- `python -m py_compile verdant_core.py`
- `python verdant_core.py > /tmp/run.log && tail -n 5 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_6854f1e9c290832587a09c9255ba948d